### PR TITLE
adding double quotes to script call

### DIFF
--- a/saseg_runner/runner.py
+++ b/saseg_runner/runner.py
@@ -77,7 +77,7 @@ def run_egp(
     if (log_dir.exists()):
         shutil.rmtree(log_dir)
     res = subprocess.run(
-        f'Cscript {SCRIPTDIR_PATH}/ExtractCodeAndLog.vbs "{output}" "{eg_version}"',
+        f'Cscript "{SCRIPTDIR_PATH}/ExtractCodeAndLog.vbs" "{output}" "{eg_version}"',
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=True,


### PR DESCRIPTION
@kjnh10 as discusssed; note that I didn't change any versions or history, just the double quotes change.

Note that I tested this with a Windows 10 machine, EG 7.1, and Python 3.9.2 64 bit. Without that quotes change, the package wouldn't work. With it, it worked great.

